### PR TITLE
fix: change interceptor unauthorized url blacklist match

### DIFF
--- a/projects/ngx-auth-utils/src/lib/interceptors/auth-expired.interceptor.ts
+++ b/projects/ngx-auth-utils/src/lib/interceptors/auth-expired.interceptor.ts
@@ -75,6 +75,6 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
             console.warn('ngx-auth-utils: Refresh token feature is enabled but unauthorizedUrlBlacklist is empty');
             console.warn('ngx-auth-utils: Blacklist at least the refresh token URL for correct session expiration handling');
         }
-        return this.unauthorizedUrlBlacklist.includes(url);
+        return this.unauthorizedUrlBlacklist.includes(new URL(url).pathname);
     }
 }


### PR DESCRIPTION
Use url pathname to match unauthorized url blacklist so that the domain is not taken into
consideration